### PR TITLE
Adds service install target

### DIFF
--- a/systemd-conf/refresher/refresh-glauth-config.service
+++ b/systemd-conf/refresher/refresh-glauth-config.service
@@ -8,3 +8,6 @@ ExecStart=/usr/sbin/refresh-glauth-config.sh
 EnvironmentFile=/etc/glauth/refresher.env
 StandardOutput=append:/var/log/refresh-glauth-config.log
 StandardError=append:/var/log/refresh-glauth-config-error.log
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds service install target so that it can be enabled for auto startup using `systemctl enable refresh-glauth-config`.